### PR TITLE
Upgrade node versions in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - "stable"
-  - "6"
+  - "12"
+  - "10"
 script:
   - npm run build
   - npm test


### PR DESCRIPTION
Since v10 is marked as the minumum required version, going to be testing v10, v12, v13 (stable) in builds since they are in support now.