### PR TITLE
Fixing http-proxy error handling to not crash on error

### DIFF
--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -24,6 +24,10 @@ class Group extends EventEmitter {
     this._proxy = httpProxy.createProxyServer({
       xfwd: true
     });
+
+    // `http-proxy` requires that at least 1 listener exists to not raise
+    // an exception. See https://github.com/http-party/node-http-proxy/blob/9b96cd725127a024dabebec6c7ea8c807272223d/lib/http-proxy/index.js#L119
+    this._proxy.on("error", err => console.error(err));
   }
 
   _output(id, data) {

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -40,6 +40,10 @@ const proxy = httpProxy.createServer({
   xfwd: true
 });
 
+// `http-proxy` requires that at least 1 listener exists to not raise
+// an exception. See https://github.com/http-party/node-http-proxy/blob/9b96cd725127a024dabebec6c7ea8c807272223d/lib/http-proxy/index.js#L119
+proxy.on("error", err => console.error(err));
+
 // Start HTTPS proxy and HTTP server
 proxy.listen(conf.port + 1);
 

--- a/test/daemon/group.js
+++ b/test/daemon/group.js
@@ -156,3 +156,10 @@ test("group.handleConnect on port 443", t => {
   sinon.assert.calledWith(tcpProxy.proxy, socket, conf.port + 1);
   t.pass();
 });
+
+test("group proxy doesnt raise exception on error", t => {
+  const group = Group();
+  // This line will raise if http-proxy doesn't have at least 1 listener
+  group._proxy.emit("error", "an error that occured");
+  t.pass();
+});


### PR DESCRIPTION
Fixing an error whereby if `http-proxy` doesn't have at least 1 error listener the proxy will crash on error.

https://github.com/http-party/node-http-proxy/blob/9b96cd725127a024dabebec6c7ea8c807272223d/lib/http-proxy/index.js#L119

