### PR TITLE
Fixing a Invalid ARG Type bug on Mac OS 10.15

### DIFF
--- a/src/pid-file.js
+++ b/src/pid-file.js
@@ -9,7 +9,7 @@ module.exports = {
 
 function create() {
   console.log("create", pidFile, process.pid);
-  return fs.writeFileSync(pidFile, process.pid);
+  return fs.writeFileSync(pidFile, process.pid.toString());
 }
 
 function read() {


### PR DESCRIPTION
Noticed that chalet originally installed then stopped working after restarting it on my MacOS with Cataline 10.15.6. Found [this](https://github.com/typicode/hotel/issues/360) thread with an [answer](https://github.com/typicode/hotel/issues/360#issuecomment-624397518) about how to fix it. I made the change locally to chalet and everything seems to work fine now. Submitting this PR since chalet seems to be interested in keeping hotel alive and well.