### PR TITLE
fix self signed certificate compatibility

### DIFF
--- a/src/daemon/pem.js
+++ b/src/daemon/pem.js
@@ -20,7 +20,9 @@ function generate() {
     const pems = selfsigned.generate(
       [{ name: "commonName", value: "chalet" }],
       {
-        days: 365
+        keySize: 2048,
+        days: 365,
+        algorithm: "sha256"
       }
     );
     fs.writeFileSync(KEY_FILE, pems.private, "utf-8");


### PR DESCRIPTION
Closes #17

Default keySize is 1024 and algorithm which is not enough nowadays.
Default algorithm is sha1 which is deprecated. https://security.googleblog.com/2014/09/gradually-sunsetting-sha-1.html

See https://github.com/jfromaniello/selfsigned/blob/c5ac42bdb5949bce47679221284331cab71a1e1e/README.md#options