### PR TITLE
don't unselect monitor on second click

### DIFF
--- a/src/app/Store.ts
+++ b/src/app/Store.ts
@@ -101,8 +101,7 @@ export default class Store {
 
   @action
   public selectMonitor(monitorId: string) {
-    this.selectedMonitorId =
-      this.selectedMonitorId === monitorId ? "" : monitorId;
+    this.selectedMonitorId = monitorId;
   }
 
   @action


### PR DESCRIPTION
hi there @jeansaad , love Chalet!! I've had a few ideas for improvements since I use it pretty much every day – this will be the first of a couple PRs, as long as you're open to some ideas!

the first is this simple change – it's common that i miss the toggle button to turn on or off a monitor, and i click the monitor again, which unselects it and prevents me from viewing any output. i'm not sure that there's much value in not viewing any monitor, which is exactly what happens when you unselect a monitor.

thanks so much!