### PR TITLE
add ability to group monitors & proxies

### DIFF
--- a/src/app/Store.ts
+++ b/src/app/Store.ts
@@ -108,12 +108,13 @@ export default class Store {
   public toggleMonitor(monitorId: string) {
     const monitor = this.monitors.get(monitorId);
 
+    const encodedMonitorId = encodeURIComponent(monitorId);
     if (monitor) {
       if (monitor.status === RUNNING) {
-        api.stopMonitor(monitorId);
+        api.stopMonitor(encodedMonitorId);
         monitor.status = STOPPED; // optimistic update
       } else {
-        api.startMonitor(monitorId);
+        api.startMonitor(encodedMonitorId);
         monitor.status = RUNNING;
       }
     }

--- a/src/app/components/MonitorList/index.css
+++ b/src/app/components/MonitorList/index.css
@@ -1,3 +1,20 @@
+.monitor {
+  height: 3rem;
+}
+
+.monitor.running * {
+  color: white;
+}
+
+.monitor:hover {
+  cursor: pointer;
+  background: var(--primary-light);
+}
+
+.monitor.selected {
+  background: var(--primary);
+}
+
 .monitor-group {
   padding-left: 1rem;
 }

--- a/src/app/components/MonitorList/index.css
+++ b/src/app/components/MonitorList/index.css
@@ -1,0 +1,3 @@
+.monitor-group {
+  padding-left: 1rem;
+}

--- a/src/app/components/MonitorList/index.tsx
+++ b/src/app/components/MonitorList/index.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import {observer} from 'mobx-react'
+import * as classNames from 'classnames'
+import {IMonitor, RUNNING} from '../../Store'
+import Link from '../Link'
+import Switch from '../Switch'
+import NavExpansionPanel from '../NavExpansionPanel';
+import "./index.css";
+
+export interface IProps {
+  monitors: Map<string, IMonitor>
+  selected: string
+  onMonitorClick?: (id: string) => void
+  onMonitorToggle?: (id: string) => void
+  depth?: number
+}
+
+function MonitorList({
+                       monitors,
+                       selected,
+                       onMonitorClick,
+                       onMonitorToggle,
+                     }: IProps) {
+  const monitorClickCallback = onMonitorClick ?? (() => undefined)
+  const monitorToggleCallback = onMonitorToggle ?? (() => undefined)
+  const groups = Array.from(monitors)
+    .filter(([id]) => id.includes('/'))
+    .reduce((prev, [id, monitor]) => {
+      const segments = id.split('/')
+      const firstSegment = segments.shift()!
+
+      if (!(firstSegment in prev)) {
+        prev[firstSegment] = new Map<string, IMonitor>()
+      }
+
+      prev[firstSegment].set(segments.join('/'), monitor)
+
+      return prev
+    }, {} as Record<string, Map<string, IMonitor>>)
+
+  return (
+    <ul>
+      {Array.from(monitors)
+        .filter(([id]) => !id.includes('/'))
+        .map(([id, monitor]) => {
+          return (
+            <li
+              key={id}
+              className={classNames('monitor', {
+                running: monitor.status === RUNNING,
+                selected: id === selected
+              })}
+              onClick={() => monitorClickCallback(id)}
+            >
+              <span>
+                <Link id={id} />
+              </span>
+              <span>
+                <Switch
+                  onClick={() => monitorToggleCallback(id)}
+                  checked={monitor.status === RUNNING}
+                />
+              </span>
+            </li>
+          )
+        })}
+      {Object.entries(groups).map(([key, group]) => {
+        return (
+          <li key={key}>
+            <NavExpansionPanel title={key} open={selected.startsWith(`${key}/`) || undefined}>
+              <div className={'monitor-group'}>
+                <MonitorList monitors={group}
+                             selected={selected.replace(new RegExp(`^${key}\/`), '')}
+                             onMonitorClick={id => monitorClickCallback(`${key}/${id}`)}
+                             onMonitorToggle={id => monitorToggleCallback(`${key}/${id}`)}
+                />
+              </div>
+            </NavExpansionPanel>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default observer(MonitorList);

--- a/src/app/components/Nav/index.css
+++ b/src/app/components/Nav/index.css
@@ -53,33 +53,19 @@ h2 {
 
 ul {
   padding: 0;
-  margin: 0 0 2rem 0;
+  margin: 0;
   list-style: none;
 }
 
 li {
   display: flex;
   justify-content: space-between;
-  height: 3rem;
   color: var(--primary-light);
   transition: border-color 0.2s;
 }
 
 li:focus {
   outline: none;
-}
-
-li.running * {
-  color: white;
-}
-
-li.monitor:hover {
-  cursor: pointer;
-  background: var(--primary-light);
-}
-
-li.selected {
-  background: var(--primary);
 }
 
 li > span {
@@ -94,4 +80,8 @@ li > span:nth-last-child() {
 
 p {
   padding: 1rem;
+}
+
+.monitors-nav {
+  margin-bottom: 2rem;
 }

--- a/src/app/components/Nav/index.tsx
+++ b/src/app/components/Nav/index.tsx
@@ -7,6 +7,7 @@ import Link from "../Link";
 import "./index.css";
 import KeyboardShortcutsModal from "../KeyboardShortcutsModal";
 import MonitorList from '../MonitorList';
+import ProxyList from '../ProxyList';
 
 const examples = `~/app$ chalet add 'cmd'
 ~/app$ chalet add 'cmd -p $PORT'
@@ -129,17 +130,7 @@ function Nav({ store }: IProps) {
         {proxies.size > 0 && (
           <div>
             <h2>proxies</h2>
-            <ul>
-              {Array.from(proxies).map(([id, proxy]) => {
-                return (
-                  <li key={id}>
-                    <span>
-                      <Link id={id} />
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
+            <ProxyList proxies={proxies} />
           </div>
         )}
       </div>

--- a/src/app/components/Nav/index.tsx
+++ b/src/app/components/Nav/index.tsx
@@ -2,11 +2,11 @@ import * as classNames from "classnames";
 import { observer } from "mobx-react";
 import KeyboardIcon from "@material-ui/icons/Keyboard";
 import * as React from "react";
-import Store, { RUNNING } from "../../Store";
+import Store from "../../Store";
 import Link from "../Link";
-import Switch from "../Switch";
 import "./index.css";
 import KeyboardShortcutsModal from "../KeyboardShortcutsModal";
+import MonitorList from '../MonitorList';
 
 const examples = `~/app$ chalet add 'cmd'
 ~/app$ chalet add 'cmd -p $PORT'
@@ -118,30 +118,11 @@ function Nav({ store }: IProps) {
         {monitors.size > 0 && (
           <div>
             <h2>monitors</h2>
-            <ul>
-              {Array.from(monitors).map(([id, monitor]) => {
-                return (
-                  <li
-                    key={id}
-                    className={classNames("monitor", {
-                      running: monitor.status === RUNNING,
-                      selected: id === selectedMonitorId,
-                    })}
-                    onClick={() => store.selectMonitor(id)}
-                  >
-                    <span>
-                      <Link id={id} />
-                    </span>
-                    <span>
-                      <Switch
-                        onClick={() => store.toggleMonitor(id)}
-                        checked={monitor.status === RUNNING}
-                      />
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
+            <MonitorList monitors={monitors}
+                         selected={selectedMonitorId}
+                         onMonitorClick={id => store.selectMonitor(id)}
+                         onMonitorToggle={id => store.toggleMonitor(id)}
+                         />
           </div>
         )}
 

--- a/src/app/components/Nav/index.tsx
+++ b/src/app/components/Nav/index.tsx
@@ -117,7 +117,7 @@ function Nav({ store }: IProps) {
         )}
 
         {monitors.size > 0 && (
-          <div>
+          <div className={'monitors-nav'}>
             <h2>monitors</h2>
             <MonitorList monitors={monitors}
                          selected={selectedMonitorId}
@@ -128,7 +128,7 @@ function Nav({ store }: IProps) {
         )}
 
         {proxies.size > 0 && (
-          <div>
+          <div className={'proxies-nav'}>
             <h2>proxies</h2>
             <ProxyList proxies={proxies} />
           </div>

--- a/src/app/components/NavExpansionPanel/index.css
+++ b/src/app/components/NavExpansionPanel/index.css
@@ -1,0 +1,33 @@
+.expansion-panel {
+  width: 100%;
+}
+
+.expansion-header {
+  display: flex;
+  height: 3rem;
+  padding: 0 1rem;
+  cursor: pointer;
+}
+
+.expansion-header:hover {
+  background: var(--primary-light);
+}
+
+.expansion-header__title {
+  flex: 1;
+  align-self: center;
+  color: #6c6c6f;
+}
+
+.expansion-header__arrow {
+  align-self: center;
+}
+
+.expansion-header__arrow svg {
+  transition: transform 0.2s ease;
+  transform-origin: center;
+}
+
+.open .expansion-header__arrow svg {
+  transform: rotate(180deg);
+}

--- a/src/app/components/NavExpansionPanel/index.tsx
+++ b/src/app/components/NavExpansionPanel/index.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import {observer} from 'mobx-react';
+import {useEffect, useState} from 'react';
+import "./index.css";
+import classNames = require('classnames');
+import {KeyboardArrowUp} from '@material-ui/icons';
+
+export interface IProps {
+  children: React.ReactNode;
+  title: string;
+  open?: boolean;
+}
+
+function NavExpansionPanel({title, open: openProp, children}: IProps) {
+  const [open, setOpen] = useState(openProp ?? false);
+  useEffect(() => setOpen(openProp ?? false), [openProp]);
+  return (
+    <div className={'expansion-panel'}>
+      <div className={classNames('expansion-header', {
+        open,
+      })} onClick={() => setOpen(!open)}>
+        <div className={'expansion-header__title'}>{title}</div>
+        <div className={'expansion-header__arrow'}>
+          <KeyboardArrowUp />
+        </div>
+      </div>
+      {open && children}
+    </div>
+  );
+}
+
+export default observer(NavExpansionPanel);

--- a/src/app/components/ProxyList/index.css
+++ b/src/app/components/ProxyList/index.css
@@ -1,3 +1,7 @@
+.proxy {
+  height: 3rem;
+}
+
 .proxy-group {
   padding-left: 1rem;
 }

--- a/src/app/components/ProxyList/index.css
+++ b/src/app/components/ProxyList/index.css
@@ -1,0 +1,3 @@
+.proxy-group {
+  padding-left: 1rem;
+}

--- a/src/app/components/ProxyList/index.tsx
+++ b/src/app/components/ProxyList/index.tsx
@@ -31,7 +31,7 @@ function ProxyList({ proxies }: IProps) {
         .filter(([id]) => !id.includes('/'))
         .map(([id, proxy]) => {
           return (
-            <li key={id}>
+            <li key={id} className={'proxy'}>
               <span>
                 <Link id={id} />
               </span>

--- a/src/app/components/ProxyList/index.tsx
+++ b/src/app/components/ProxyList/index.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import {observer} from 'mobx-react';
+import {IProxy} from '../../Store';
+import Link from '../Link';
+import NavExpansionPanel from '../NavExpansionPanel';
+import "./index.css";
+
+export interface IProps {
+  proxies: Map<string, IProxy>;
+}
+
+function ProxyList({ proxies }: IProps) {
+  const groups = Array.from(proxies)
+    .filter(([id]) => id.includes('/'))
+    .reduce((prev, [id, proxy]) => {
+      const segments = id.split('/')
+      const firstSegment = segments.shift()!
+
+      if (!(firstSegment in prev)) {
+        prev[firstSegment] = new Map<string, IProxy>()
+      }
+
+      prev[firstSegment].set(segments.join('/'), proxy)
+
+      return prev
+    }, {} as Record<string, Map<string, IProxy>>)
+
+  return (
+    <ul>
+      {Array.from(proxies)
+        .filter(([id]) => !id.includes('/'))
+        .map(([id, proxy]) => {
+          return (
+            <li key={id}>
+              <span>
+                <Link id={id} />
+              </span>
+            </li>
+          )
+        })}
+      {Object.entries(groups).map(([key, group]) => {
+        return (
+          <li key={key}>
+            <NavExpansionPanel title={key}>
+              <div className={'proxy-group'}>
+                <ProxyList proxies={group}
+                />
+              </div>
+            </NavExpansionPanel>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default observer(ProxyList);

--- a/src/daemon/loader.js
+++ b/src/daemon/loader.js
@@ -6,7 +6,7 @@ const log = require("./log");
 const common = require("../common");
 
 function getId(file) {
-  return path.basename(file, ".json");
+  return path.relative(common.serversDir, file).replace(/.json$/, "");
 }
 
 function handleAdd(group, file) {
@@ -34,6 +34,18 @@ function handleChange(group, file) {
   });
 }
 
+function getFilesRecursive(dir) {
+  const entries = fs.readdirSync(dir);
+
+  return entries.reduce((prev, curr) => {
+    const absolutePath = path.resolve(dir, curr);
+    if (fs.lstatSync(absolutePath).isDirectory()) {
+      return [...prev, ...getFilesRecursive(absolutePath)];
+    }
+    return [...prev, absolutePath];
+  }, []);
+}
+
 module.exports = (group, opts = { watch: true }) => {
   const dir = common.serversDir;
 
@@ -51,7 +63,7 @@ module.exports = (group, opts = { watch: true }) => {
   }
 
   // Bootstrap
-  fs.readdirSync(dir).forEach(file => {
+  getFilesRecursive(dir).forEach(file => {
     handleAdd(group, path.resolve(dir, file));
   });
 };


### PR DESCRIPTION
Hey there 🙂 

Amazing work your doing here maintaining this awesome tool 🙂 

I currently have the pain that ui gets pretty messy when dealing with a hugh amount of servers.

This PR adds the ability to group monitors & proxies within expansion panels by folder structure inside the servers directory.

Given folder structure:

```
|-- servers
    |-- top-level-project.json
    |-- @rohmer
    |   |-- design-system.json
    |-- fancy-app
        |-- backend.json
        |-- ui.json
        |-- tests
            |-- cypress.json
            |-- jest.json
```

Would result in a ui structure like so:

<img width="352" alt="Screenshot 2021-11-07 at 16 07 46" src="https://user-images.githubusercontent.com/22852029/140650680-841cc70b-5f8f-4303-a17c-dd88cdff2b3e.png">
