### PR TITLE
Swap nav hovered and selected styles

### DIFF
--- a/src/app/components/Nav/index.css
+++ b/src/app/components/Nav/index.css
@@ -75,11 +75,11 @@ li.running * {
 
 li.monitor:hover {
   cursor: pointer;
-  background: var(--primary-light);
+  background: var(--primary);
 }
 
-li.selected {
-  background: var(--primary);
+li.selected,li.selected:hover {
+  background: var(--primary-light);
 }
 
 li > span {


### PR DESCRIPTION
Since the current hovered style is lighter than our selected style, there are times when i think that my hovered nav item is actually the selected one. This PR swaps those colors to make the UI a bit clearer. It also makes a change that when you hover on the selected item, we should keep the selected style instead of getting darker.

https://user-images.githubusercontent.com/14222277/156610866-ce7d0a73-fd1e-4881-be44-40b4240af703.mov

