### PR TITLE
Replaced localhost url when logging on deamon start

### DIFF
--- a/src/cli/daemon.js
+++ b/src/cli/daemon.js
@@ -25,7 +25,7 @@ function start() {
   mkdirp.sync(common.chaletDir);
   fs.writeFileSync(common.startupFile, startupFile);
 
-  console.log(`Started http://localhost:${conf.port}`);
+  console.log(`Started http://${conf.host}:${conf.port}`);
 }
 
 // Stop daemon


### PR DESCRIPTION
Replaced the url that gets printed when the cli deamon starts to display conf.host instead of always printing localhost