### PR TITLE
Add vite example to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ chalet add 'python -m SimpleHTTPServer $PORT'           # static file server (Py
 chalet add 'php -S 127.0.0.1:$PORT'                     # PHP
 chalet add 'docker-compose up'                          # docker-compose
 chalet add 'python manage.py runserver 127.0.0.1:$PORT' # Django
+chalet add 'npm run dev -- --port $PORT'                # Vite Dev Server
 # ...
 ```
 


### PR DESCRIPTION
I struggled with getting Vite working in chalet and finally figured out that it needed the $PORT var included in the cmd as shown in some of the other examples. Since Vite is pretty popular these days I thought it was worth adding an explicit example in the ReadMe.